### PR TITLE
Enviorement variables fix

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -69,7 +69,7 @@ class MWSClient
         $this->secretKey = config('amazon-mws.secret_key');
         $this->sellerId = config('amazon-mws.seller_id');
         $this->mwsAuthToken = config('amazon-mws.mws_auth_token') ?: null;
-        $this->marketPlaces = explode(',', config('amazon-mws.default_market_place'));
+        $this->marketPlaces = explode(',', config('amazon-mws.default_market_place') ?: 'DE');
         $this->client = $client ?: new Client(['timeout'  => 60]);
     }
 

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -68,8 +68,8 @@ class MWSClient
         $this->accessKeyId = config('amazon-mws.access_key_id');
         $this->secretKey = config('amazon-mws.secret_key');
         $this->sellerId = config('amazon-mws.seller_id');
-        $this->mwsAuthToken = config('amazon-mws.mws_auth_token');
-        $this->marketPlaces = ['DE'];
+        $this->mwsAuthToken = config('amazon-mws.mws_auth_token') ?: null;
+        $this->marketPlaces = explode(',', config('amazon-mws.default_market_place'));
         $this->client = $client ?: new Client(['timeout'  => 60]);
     }
 


### PR DESCRIPTION
This PR try to improve the way in which the enviorement variables from .env are read.

- **mws_auth_token**: If *mws_auth_token* is not set, the default value is a empty string. It'll appear in the POST request like "...&MWSAuthToken=&..." causing an error. With this PR, if it's not set, its value will be *null*, disappearing from the request.

- **default_market_place**: Right now, this var is ignored (*['DE']* is hard-coded). With this PR, it's read and parsed as array (the string is exploded with commas as delimiter)